### PR TITLE
[WIP]chat-spaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |------|----|-------|
 |email|string|null: false, unique: true|
 |password|string|null: false|
-|username|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :messages
 - has_many :groups_users
@@ -28,9 +28,9 @@ add_index :user, :username
 ## groupテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|name|string|null: false|
 ### Association
-- has_many :message
+- has_many :messages
 - has_many :groups_users
 - has_many :users, through: :groups_users
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,47 @@
 # README
+# chatspace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false, unique: true|
+|password|string|null: false|
+|username|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :groups, through: :groups_users
+### index
+add_index :user, :username
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## messageテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text||
+|image|text||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|create_at|string|null: false|
+### Association
+- belongs_to :user
+- belongs_to :group
 
-Things you may want to cover:
+## groupテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+### Association
+- has_many :message
+- has_many :groups_users
+- has_many :users, through: :groups_users
 
-* Ruby version
 
-* System dependencies
+## groups_usersテーブル
 
-* Configuration
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
# What
chat-space実装のため、DB設計を行い、README.mdに記述しました。
テーブルはuserテーブル, messageテーブル,groupテーブルとuser_idとgroup_idを有するgroups_usersテーブルが必要と考えました。

## userテーブル
usernameカラム、passwordカラム、emailカラムが必要と考えました。それぞれ、not null制約を与え、emailだけに一意性制約を与えました。
また、グループ作成時にusernameを検索するので、usernameカラムにインデックスを付けました。

## messageテーブル
bodyカラム、imageカラム、user_idカラム、group_idカラム、create_atカラムが必要と考えました。
bodyカラム、imageカラムはバリデーションで、どちらも空の場合は投稿できないように設定すればいいのではないかと思いました。
user_idカラム、group_idカラムにはnot null制約に加え、外部キー制約を付けました。

## groupテーブル
groupnameカラムが必要と考えました。また、not null制約を付けました

## groups_usersテーブル
groupテーブルとuserテーブルは多対多なので、中間テーブルとなるgroups_usersテーブルを作成しました。
user_idカラムとgroup_idが必要と考えました。それぞれに、not null制約と外部キー制約を付けました。

# Why
DB設計は本アプリケーションの根幹であるため。